### PR TITLE
Added detection of authentication type for Edimax firmware >= 2.03

### DIFF
--- a/src/ediplug/smartplug.py
+++ b/src/ediplug/smartplug.py
@@ -29,6 +29,7 @@ import logging as log
 
 from xml.dom.minidom import getDOMImplementation
 from xml.dom.minidom import parseString
+from requests.auth import HTTPDigestAuth
 
 __author__ = 'Stefan Wendler, sw@kaltpost.de'
 
@@ -140,6 +141,11 @@ class SmartPlug(object):
         self.url = "http://%s:10000/smartplug.cgi" % host
         self.auth = auth
         self.domi = getDOMImplementation()
+
+        # Make a request to detect if Authentication type is Digest
+        res = requests.head(self.url)
+        if res.headers['WWW-Authenticate'][0:6] == 'Digest':
+            self.auth = HTTPDigestAuth(auth[0], auth[1])
 
         self.log = log.getLogger("SmartPlug")
 


### PR DESCRIPTION
The same fix as here: https://github.com/rkabadi/pyedimax/pull/5/commits/1e4ed5dc00549951dd4731bf2284b805934e77c2

Ediplug firmware 2.03 (i think) and greater have Digest auth.
