### PR TITLE
Fixed a runtime error caused by referencing a package by wrong name

### DIFF
--- a/src/ediplug/smartplug.py
+++ b/src/ediplug/smartplug.py
@@ -143,7 +143,7 @@ class SmartPlug(object):
         self.domi = getDOMImplementation()
 
         # Make a request to detect if Authentication type is Digest
-        res = requests.head(self.url)
+        res = req.head(self.url)
         if res.headers['WWW-Authenticate'][0:6] == 'Digest':
             self.auth = HTTPDigestAuth(auth[0], auth[1])
 


### PR DESCRIPTION
Probably as a fallout from the previous pull request the following was happening:

```
Traceback (most recent call last):
  File "src/ediplug/smartplug.py", line 658, in <module>
    p = SmartPlug(options.host, (options.login, options.password))
  File "src/ediplug/smartplug.py", line 146, in __init__
    res = requests.head(self.url)
NameError: name 'requests' is not defined
```

The fix is trivial.

Resolves #9